### PR TITLE
Fixed issue with GitHub Actions.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,34 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+    - uses: actions/setup-java@v1
+      with:
+          java-version: '11.0.8'
+          java-package: jdk
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+    - name: Test
+      run: go test ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,17 @@ jobs:
       with:
         go-version: ^1.13
       id: go
-    - uses: actions/setup-java@v1
+    - name: Set up Java 11.0.8
+      uses: actions/setup-java@v1
       with:
           java-version: '11.0.8'
           java-package: jdk
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+          python-version: '3.6'
+    - name: Install Numpy
+      run: python -m pip install --upgrade numpy
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Get dependencies


### PR DESCRIPTION
The errors that were previously occurring when running the tests in GitHub Actions were caused by the incompatibility of our Java runner implementation with Java 8. I restored .github/workflows/go.yml and updated it to require Java 11.0.8, Python 3.6 (previously the python version was unspecified), and NumPy.