### PR TITLE
Write Server Package

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+    "context"
+    "fmt"
+    "net/http"
+)
+
+type HTTPServer interface {
+    Start(port int) error
+
+    Stop() error
+}
+
+func NewHTTPServer() HTTPServer {
+    return &httpServer{}
+}
+
+type httpServer struct {
+    server *http.Server
+}
+
+func (server *httpServer) Start(port int) error {
+    serveMux := newServeMux()
+    server.server = &http.Server {
+        Addr: fmt.Sprintf(":%d", port),
+        Handler: serveMux,
+    }
+    return server.server.ListenAndServe()
+}
+
+func (server *httpServer) Stop() error {
+    return server.server.Shutdown(context.Background())
+}

--- a/internal/server/server_serve_mux.go
+++ b/internal/server/server_serve_mux.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+    "encoding/json"
+    "fmt"
+    "github.com/lkelly93/scheduler/internal/executable"
+    "io/ioutil"
+    "log"
+    "net/http"
+    "strings"
+)
+
+const codeCharacterLimit = 80000
+
+type executeHandler struct{
+}
+
+type errorResponse struct {
+    ErrorType string
+    Error string
+}
+
+type executionOutputResponse struct {
+    Stdout string
+}
+
+func writeJSON(rw http.ResponseWriter, obj interface{}) error {
+    b, err := json.Marshal(obj)
+    if (err != nil) {
+        return err
+    }
+    _, err = rw.Write(b)
+    if (err != nil) {
+        return err
+    }
+    return nil
+}
+
+func writeErrorResponse(rw http.ResponseWriter, code int, errorType string, reason string) {
+    rw.WriteHeader(code)
+    writeJSON(rw, errorResponse {
+        ErrorType: errorType,
+        Error: reason,
+    })
+}
+
+func invalidRequest(rw http.ResponseWriter, reason string) {
+    writeErrorResponse(rw, 400, "Invalid Request", reason)
+}
+
+func notFound(rw http.ResponseWriter, path string) {
+    writeErrorResponse(rw, 404, "Not Found", path + " not found.")
+}
+
+func (executeHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+    if (req.Method != "POST") {
+        invalidRequest(rw, "/execute/<language> requires POST.")
+        return
+    }
+
+    path := strings.Split(req.URL.Path, "/")
+    if (len(path) > 3) {
+        notFound(rw, req.URL.Path)
+        return
+    }
+
+    if (path[2] == "") {
+        invalidRequest(rw, "/execute/<language> requires language.")
+        return
+    }
+
+    language := path[2]
+    codeBytes, err := ioutil.ReadAll(req.Body)
+    if (err != nil) {
+        log.Println("[ERROR] Unable to read HTTP request.")
+        rw.WriteHeader(500)
+        return
+    }
+    var msg map[string]interface{}
+    err = json.Unmarshal(codeBytes, &msg)
+    if (err != nil) {
+        invalidRequest(rw, "Invalid JSON (Could not parse JSON).")
+        return
+    }
+    _, ok := msg["Code"]
+    if (!ok) {
+        invalidRequest(rw, "Code is a required field.")
+        return
+    }
+
+    code, ok := msg["Code"].(string)
+    if (!ok) {
+        invalidRequest(rw, "Code must be a string.")
+        return
+    }
+    if (len(code) > codeCharacterLimit) {
+        invalidRequest(rw, fmt.Sprintf("Code character limit of %d chars exceeded.", codeCharacterLimit))
+        return
+    }
+
+    exec, err := executable.NewExecutable(language, code, nil)
+
+    if (err != nil) {
+        writeErrorResponse(rw, 400, "unsupported_language",
+            fmt.Sprintf("%s is not a supported language.", language))
+        return
+    }
+
+    //TODO add exec to queue here...
+    stdout := exec.Run()
+    rw.WriteHeader(200)
+    writeJSON(rw, executionOutputResponse{
+        Stdout: stdout,
+    })
+}
+
+func newServeMux() *http.ServeMux {
+    sm := http.NewServeMux()
+    sm.Handle("/execute/", executeHandler{})
+    return sm;
+}

--- a/internal/server/server_serve_mux_test.go
+++ b/internal/server/server_serve_mux_test.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+    "io/ioutil"
+    "encoding/json"
+    "fmt"
+    "reflect"
+    "strings"
+    "testing"
+    "net/http"
+    "net/http/httptest"
+)
+
+/////////////
+// Utility //
+/////////////
+
+type responseWrapper struct {
+    res *http.Response
+
+    pattern string
+}
+
+func (rw responseWrapper) expectCode(t *testing.T, code int) responseWrapper {
+    if (rw.res.StatusCode != code) {
+        t.Errorf("Expected HTTP %d, got HTTP %d", code, rw.res.StatusCode)
+    }
+    return rw
+}
+
+func (rw responseWrapper) expectJSON(t *testing.T, expectedJSON string) responseWrapper {
+    var expected interface{}
+    if (json.Unmarshal([]byte(expectedJSON), &expected) != nil) {
+        t.Fatalf("Could not unmarshal expectedJSON.")
+    }
+    body, _ := ioutil.ReadAll(rw.res.Body)
+    var actual interface{}
+    if (json.Unmarshal(body, &actual) != nil) {
+        t.Fatalf("Response body is not valid JSON.")
+    }
+    if (!reflect.DeepEqual(expected, actual)) {
+        t.Errorf("Expected %s, got %s", expected, actual)
+    }
+    return rw
+}
+
+func (rw responseWrapper) expectErrorResponse(t *testing.T, errorType string, reason string) responseWrapper {
+    expected := errorResponse{
+        ErrorType: errorType,
+        Error: reason,
+    }
+    expectedJSON, _ := json.Marshal(expected)
+    return rw.expectJSON(t, string(expectedJSON))
+}
+
+func getsm(sm *http.ServeMux, target string) responseWrapper {
+    req := httptest.NewRequest("GET", target, nil)
+    handler, pattern := sm.Handler(req)
+    rr := httptest.NewRecorder()
+    handler.ServeHTTP(rr, req)
+    return responseWrapper{res: rr.Result(), pattern: pattern}
+}
+
+func get(target string) responseWrapper {
+    sm := newServeMux()
+    return getsm(sm, target)
+}
+
+func postsm(sm *http.ServeMux, target string, body string) responseWrapper {
+    req := httptest.NewRequest("POST", target, strings.NewReader(body))
+    handler, pattern := sm.Handler(req)
+    rr := httptest.NewRecorder()
+    handler.ServeHTTP(rr, req)
+    return responseWrapper{res: rr.Result(), pattern: pattern}
+}
+
+func post(target string, body string) responseWrapper {
+    sm := newServeMux()
+    return postsm(sm, target, body)
+}
+
+///////////
+// Tests //
+///////////
+
+func Test_Execute_Language(t *testing.T) {
+    t.Run("GET /execute/python returns HTTP 400", func(t *testing.T) {
+        get("/execute/python").
+        expectCode(t, 400)
+    })
+
+    t.Run("GET /execute/unsupportedLanguage", func(t *testing.T) {
+        get("/execute/unsupportedLanguage").
+        expectCode(t, 400)
+    })
+
+    t.Run("POST /execute/unsupportedLanguage", func(t *testing.T) {
+        post("/execute/unsupportedLanguage", `{ "Code": "print(\"Hello World\")" }`).
+        expectJSON(t, `{"ErrorType":"unsupported_language",
+                        "Error": "unsupportedLanguage is not a supported language."}`)
+    })
+
+    t.Run("POST /execute/differentUnsupportedLanguage", func(t *testing.T) {
+        post("/execute/differentUnsupportedLanguage", `{ "Code": "print(\"Hello World\")" }`).
+        expectJSON(t, `{"ErrorType":"unsupported_language",
+                        "Error": "differentUnsupportedLanguage is not a supported language."}`)
+    })
+
+    t.Run("POST /execute/python with correct JSON", func(t *testing.T) {
+        post("/execute/python", `{ "Code": "print(\"Hello World\")" }`).
+        expectCode(t, 200).
+        expectJSON(t, `{"Stdout": "Hello World\n"}`)
+    })
+
+    t.Run("POST /execute/python with valid but incorrect JSON", func(t *testing.T) {
+        post("/execute/python", `{}`).
+        expectCode(t, 400)
+    })
+
+    t.Run("POST /execute/python with invalid JSON", func(t *testing.T) {
+        post("/execute/python", `}`).
+        expectCode(t, 400)
+    })
+
+    t.Run("POST /execute/python/extraneous", func(t *testing.T) {
+        post("/execute/python/extraneous", `{}`).
+        expectCode(t, 404)
+    })
+
+    t.Run("POST /execute/", func(t *testing.T) {
+        post("/execute/", `{}`).
+        expectCode(t, 400).
+        expectErrorResponse(t, "Invalid Request", "/execute/<language> requires language.")
+    })
+
+    t.Run("POST /execute/python non-string Code", func(t *testing.T) {
+        post("/execute/python", `{"Code": 123}`).
+        expectCode(t, 400).
+        expectErrorResponse(t, "Invalid Request", "Code must be a string.")
+    })
+
+    t.Run("POST /execute/python code reaches character limit", func(t *testing.T) {
+        before := "print(\\\""
+        after := "\\\")"
+        var b strings.Builder
+        // add 2 since escape characters get dropped
+        for i := 0; i < codeCharacterLimit - len(before) - len(after) + 2; i++ {
+            fmt.Fprintf(&b, "-")
+        }
+        fmt.Println(codeCharacterLimit)
+        code := fmt.Sprint(before, b.String(), after)
+        post("/execute/python", fmt.Sprintf(`{"Code": "%s"}`, code)).
+        expectCode(t, 200).
+        expectJSON(t, fmt.Sprintf(`{"Stdout": "%s\n"}`, b.String()))
+    })
+
+    t.Run("POST /execute/python exceeding code character limit", func(t *testing.T) {
+        var b strings.Builder
+        before := "print(\\\""
+        after := "\\\")"
+        fmt.Fprintf(&b, before)
+        // add 2 since escape characters get dropped
+        for i := 0; i < codeCharacterLimit - len(before) - len(after) + 3; i++ {
+            fmt.Fprintf(&b, "-")
+        }
+        fmt.Fprintf(&b, after)
+        code := b.String()
+        //fmt.Printf(`{"Code": "%s"}`, code)
+        post("/execute/python", fmt.Sprintf(`{"Code": "%s"}`, code)).
+        expectCode(t, 400).
+        expectErrorResponse(t, "Invalid Request",
+            fmt.Sprintf("Code character limit of %d chars exceeded.", codeCharacterLimit))
+    })
+}
+
+// returns code 200 on compilation error w/ JSON body in format:
+// { "ErrorType": "compilation",
+//   "Error": "..." }
+// (compilation error is returned by Run function)
+//
+// returns code 200 on runtime error w/ JSON body in format:
+// { "ErrorType": "runtime",
+//   "Error": "..." }
+//
+// returns code 400 when code is too long w/ JSON body in format:
+// { "Error": "Code execeeds character limit." }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+    "testing"
+    "time"
+    "net/http"
+)
+
+func TestStartHTTPServer(t *testing.T) {
+    srv := NewHTTPServer()
+    go srv.Start(8765)
+    defer srv.Stop()
+    time.Sleep(1 * time.Second)
+    _, err := http.Get("http://localhost:8765")
+    if (err != nil) {
+        t.Errorf("Expected nil err from http.Get but got:  %s", err)
+    }
+}
+
+func TestStopHTTPServer(t *testing.T) {
+    srv := NewHTTPServer()
+    go srv.Start(8765)
+    time.Sleep(1 * time.Second)
+    srv.Stop()
+    _, err := http.Get("http://localhost:8765")
+    if (err == nil) {
+        t.Errorf("Expected connection refused error.")
+    }
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/lkelly93/scheduler/internal/server"
+
+func main() {
+    server := server.NewHTTPServer()
+    server.Start(3000)
+}


### PR DESCRIPTION
### Summary
This pull request contains the initial implementation of the HTTP API for this project. Currently, the only supported endpoint is /execute/<language>, where <language> is one of the supported languages (currently python or java). This endpoint responds to POST requests with a JSON body in the form `{"Code": "<code>"}` where `<code>` is the code to be executed, and responds with JSON in the form `{"Stdout": "<output>" }`.

### Structure
The HTTP server implementation in the net/http package relies on a ServeMux type to determine how any requests should be handled (and call the appropriate handlers).

`server.go` handles setting up the server, while `server_serve_mux.go` handles creating a ServeMux instance and its associated request handlers.