### PR TITLE
Refactor executes errors

### DIFF
--- a/internal/executable/executable.go
+++ b/internal/executable/executable.go
@@ -5,7 +5,6 @@ package executable
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,15 +17,15 @@ import (
 func NewExecutable(lang string, code string, settings *FileSettings) (Executable, error) {
 	function := getFileCreationFunction(lang)
 	if function != nil {
-		state := executableState{
+		return &executableState{
 			code:       code,
 			settings:   settings,
 			createFile: function,
-		}
-		return &state, nil
+		}, nil
 	}
-	err := fmt.Sprintf("%s is not a supported language", lang)
-	return nil, errors.New(err)
+	return nil, &UnsupportedLanguageError{
+		lang: lang,
+	}
 }
 
 //Run runs the given program and then returns the output, this could be the

--- a/internal/executable/executable.go
+++ b/internal/executable/executable.go
@@ -5,7 +5,6 @@ package executable
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"time"
@@ -30,10 +29,15 @@ func NewExecutable(lang string, code string, settings *FileSettings) (Executable
 
 //Run runs the given program and then returns the output, this could be the
 //output from a successful run or the error message from an unsuccessful run.
-func (state *executableState) Run() string {
+func (state *executableState) Run() (string, error) {
 	timeoutInSeconds := 15
-	//Create the file and get the data to run it
-	sysCommand, fileLocation := state.createFile(state.code, state.settings)
+	//Create the file and get the data to run it. If sys command is an empty
+	//string then we had a compilation error and the error is stored in the
+	//fileLocation variable.
+	sysCommand, fileLocation, err := state.createFile(state.code, state.settings)
+	if err != nil {
+		return "", err
+	}
 	//Remove the old files
 	defer os.Remove(fileLocation)
 
@@ -53,13 +57,14 @@ func (state *executableState) Run() string {
 	command.Stderr = &stErr
 
 	//Run the command and get the stdOut/stdErr
-	err := command.Run()
+	err = command.Run()
 	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Sprintf("Time Limit Exceeded %ds", timeoutInSeconds)
+		return "", &TimeLimitExceeded{maxTime: timeoutInSeconds}
 	}
 	if err != nil {
-		return removeFilePath(stErr.String(), fileLocation)
+		errorMessage := removeFilePath(stErr.String(), fileLocation)
+		return "", &RuntimeError{errMessage: errorMessage}
 	}
 
-	return string(stOut.String())
+	return string(stOut.String()), nil
 }

--- a/internal/executable/executable.go
+++ b/internal/executable/executable.go
@@ -59,7 +59,7 @@ func (state *executableState) Run() (string, error) {
 	//Run the command and get the stdOut/stdErr
 	err = command.Run()
 	if ctx.Err() == context.DeadlineExceeded {
-		return "", &TimeLimitExceeded{maxTime: timeoutInSeconds}
+		return "", &TimeLimitExceededError{maxTime: timeoutInSeconds}
 	}
 	if err != nil {
 		errorMessage := removeFilePath(stErr.String(), fileLocation)

--- a/internal/executable/executable_long_test.go
+++ b/internal/executable/executable_long_test.go
@@ -24,12 +24,13 @@ func TestInfiniteRecursion(t *testing.T) {
 	}
 
 	expected := "Exception in thread \"main\" java.lang.StackOverflowError\n"
-	actual := prog.Run()
+	_, actual := prog.Run()
 
-	newLineIndex := strings.Index(actual, "\n") + 1
-	actual = actual[:newLineIndex]
+	errorMessage := actual.Error()
+	newLineIndex := strings.Index(errorMessage, "\n") + 1
+	errorMessage = errorMessage[:newLineIndex]
 
-	assertEquals(expected, actual, t)
+	assertEquals(expected, errorMessage, t)
 }
 
 func TestInfiniteLoop(t *testing.T) {
@@ -39,8 +40,8 @@ func TestInfiniteLoop(t *testing.T) {
 	code.WriteString("\tx+=1\n")
 	prog, _ := NewExecutable("python", code.String(), nil)
 
-	actual := prog.Run()
+	_, actual := prog.Run()
 	expected := "Time Limit Exceeded 15s"
 
-	assertEquals(expected, actual, t)
+	assertEquals(expected, actual.Error(), t)
 }

--- a/internal/executable/executable_long_test.go
+++ b/internal/executable/executable_long_test.go
@@ -30,6 +30,7 @@ func TestInfiniteRecursion(t *testing.T) {
 	newLineIndex := strings.Index(errorMessage, "\n") + 1
 	errorMessage = errorMessage[:newLineIndex]
 
+	assertRuntimeError(actual, t)
 	assertEquals(expected, errorMessage, t)
 }
 
@@ -43,5 +44,6 @@ func TestInfiniteLoop(t *testing.T) {
 	_, actual := prog.Run()
 	expected := "Time Limit Exceeded 15s"
 
+	assertTimeLimitError(actual, t)
 	assertEquals(expected, actual.Error(), t)
 }

--- a/internal/executable/executable_test.go
+++ b/internal/executable/executable_test.go
@@ -24,6 +24,7 @@ func TestNewExecutable(t *testing.T) {
 func TestNewExecutableFail(t *testing.T) {
 	lang := "Not a Language"
 	_, err := NewExecutable(lang, "Not Code", nil)
+	assertUnsupportedLanguageError(err, t)
 	if err == nil {
 		t.Errorf("\"%s\" was accepted as a language and should not of been.", lang)
 	}
@@ -184,10 +185,6 @@ func genericRunCode(prog Executable, expected string, t *testing.T) {
 
 func genericRuntimeErrorTest(prog Executable, expected string, t *testing.T) {
 	_, actual := prog.Run()
-	_, ok := actual.(*RuntimeError)
-	if !ok {
-		t.Errorf("Expected RuntimeError but got %T", actual)
-		return
-	}
+	assertRuntimeError(actual, t)
 	assertEquals(expected, actual.Error(), t)
 }

--- a/internal/executable/executable_test.go
+++ b/internal/executable/executable_test.go
@@ -50,7 +50,7 @@ func TestRunPythonCodeCustomFileSettings(t *testing.T) {
 	}
 	exec, _ := NewExecutable(lang, code, &settings)
 
-	actual := exec.Run()
+	actual, _ := exec.Run()
 	expected := "2.718281828459045\n6.283185307179586\n"
 	assertEquals(expected, actual, t)
 }
@@ -72,7 +72,12 @@ func TestRunJavaCodeCustomFileSettings(t *testing.T) {
 	}
 	exec, _ := NewExecutable(lang, code.String(), &settings)
 
-	actual := exec.Run()
+	actual, err := exec.Run()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expected := "4\n3.141592653589793\n"
 	assertEquals(expected, actual, t)
 }
@@ -156,7 +161,7 @@ func TestRunBadJavaCode(t *testing.T) {
 		"2 errors\n" +
 		"error: compilation failed\n"
 
-	genericRunBadCode(prog, expected, t)
+	genericRuntimeErrorTest(prog, expected, t)
 
 }
 
@@ -167,17 +172,22 @@ func TestRunBadPythonCode(t *testing.T) {
 		"            ^\n" +
 		"SyntaxError: EOL while scanning string literal\n"
 
-	genericRunBadCode(prog, expected, t)
+	genericRuntimeErrorTest(prog, expected, t)
 }
 
 /***** Supporting Methods *****/
 func genericRunCode(prog Executable, expected string, t *testing.T) {
-	actual := prog.Run()
+	actual, _ := prog.Run()
 
 	assertEquals(expected, actual, t)
 }
 
-func genericRunBadCode(prog Executable, expected string, t *testing.T) {
-	actual := prog.Run()
-	assertEquals(expected, actual, t)
+func genericRuntimeErrorTest(prog Executable, expected string, t *testing.T) {
+	_, actual := prog.Run()
+	_, ok := actual.(*RuntimeError)
+	if !ok {
+		t.Errorf("Expected RuntimeError but got %T", actual)
+		return
+	}
+	assertEquals(expected, actual.Error(), t)
 }

--- a/internal/executable/file_handler_test.go
+++ b/internal/executable/file_handler_test.go
@@ -26,7 +26,7 @@ func TestPythonCreateFileCustomFileSettings(t *testing.T) {
 	expectedRunnerFile := "../runner_files/PREFIXSillyPythonName.py"
 
 	function := getFileCreationFunction(lang)
-	_, fileLocation := function(code, &fileSettings)
+	_, fileLocation, _ := function(code, &fileSettings)
 	os.Remove(fileLocation)
 
 	assertEquals(expectedRunnerFile, fileLocation, t)
@@ -43,7 +43,7 @@ func TestJavaCreateFileCustomFileSettings(t *testing.T) {
 	expectedRunnerFile := "../runner_files/PREFIXSillyJavaName.java"
 
 	function := getFileCreationFunction(lang)
-	_, fileLocation := function(code, &fileSettings)
+	_, fileLocation, _ := function(code, &fileSettings)
 	os.Remove(fileLocation)
 
 	assertEquals(expectedRunnerFile, fileLocation, t)
@@ -62,7 +62,7 @@ func TestCreateRunnerFile(t *testing.T) {
 	code := "print('Hello World')"
 
 	createFileFunction := getFileCreationFunction(lang)
-	_, fileLocation := createFileFunction(code, nil)
+	_, fileLocation, _ := createFileFunction(code, nil)
 	defer os.Remove(fileLocation)
 
 	_, err := os.Stat(fileLocation)
@@ -146,7 +146,7 @@ func TestGetRunnerFileLocation(t *testing.T) {
 func genericCreateFile(lang string, code string, expected string, t *testing.T) {
 	createFileFunction := getFileCreationFunction(lang)
 
-	sysCommand, fileLocation := createFileFunction(code, nil)
+	sysCommand, fileLocation, _ := createFileFunction(code, nil)
 	defer os.Remove(fileLocation)
 
 	actual := sysCommand + " " + fileLocation

--- a/internal/executable/generic_methods_test.go
+++ b/internal/executable/generic_methods_test.go
@@ -33,8 +33,8 @@ func assertCompilationError(err error, t *testing.T) {
 }
 
 func assertTimeLimitError(err error, t *testing.T) {
-	if _, ok := err.(*TimeLimitExceeded); !ok {
-		t.Errorf("Expected TimeLimitExceeded but got %T", err)
+	if _, ok := err.(*TimeLimitExceededError); !ok {
+		t.Errorf("Expected TimeLimitExceededError but got %T", err)
 	}
 }
 

--- a/internal/executable/generic_methods_test.go
+++ b/internal/executable/generic_methods_test.go
@@ -19,3 +19,27 @@ func assertEquals(expected string, actual string, t *testing.T) {
 		t.Errorf("Error at index %d, expected %c but was %c", i, expectedChar, actualChar)
 	}
 }
+
+func assertRuntimeError(err error, t *testing.T) {
+	if _, ok := err.(*RuntimeError); !ok {
+		t.Errorf("Expected RuntimeError but got %T", err)
+	}
+}
+
+func assertCompilationError(err error, t *testing.T) {
+	if _, ok := err.(*CompilationError); !ok {
+		t.Errorf("Expected CompilationError but got %T", err)
+	}
+}
+
+func assertTimeLimitError(err error, t *testing.T) {
+	if _, ok := err.(*TimeLimitExceeded); !ok {
+		t.Errorf("Expected TimeLimitExceeded but got %T", err)
+	}
+}
+
+func assertUnsupportedLanguageError(err error, t *testing.T) {
+	if _, ok := err.(*UnsupportedLanguageError); !ok {
+		t.Errorf("Expected UnsupportedLanguageError but got %T", err)
+	}
+}

--- a/internal/executable/runner_java.go
+++ b/internal/executable/runner_java.go
@@ -6,26 +6,28 @@ import (
 )
 
 //Java creates a runnerFile for java languages.
-func createRunnerFileJava(code string, settings *FileSettings) (string, string) {
+func createRunnerFileJava(code string, settings *FileSettings) (string, string, error) {
 	settings = fillRestOfFileSettings("java", settings)
 	langCommand := "java"
-	var fileName strings.Builder
-	fileName.WriteString(settings.FileNamePrefix)
-	fileName.WriteString(settings.ClassName)
-	fileName.WriteString(".java")
-	outFileName := getRunnerFileLocation(fileName.String())
+	var runnerFileName strings.Builder
+	runnerFileName.WriteString(settings.FileNamePrefix)
+	runnerFileName.WriteString(settings.ClassName)
+	runnerFileName.WriteString(".java")
+	runnerFileLocation := getRunnerFileLocation(runnerFileName.String())
 
 	var formattedCode strings.Builder
 	insertImportsJava(&formattedCode, settings)
 	formattedCode.WriteString(code)
 	insertTrailingCodeJava(&formattedCode, settings)
 
-	err := createFileAndAddCode(outFileName, formattedCode.String())
-
+	err := createFileAndAddCode(runnerFileLocation, formattedCode.String())
 	if err != nil {
 		log.Fatal("Could not create runner file!")
 	}
-	return langCommand, outFileName
+
+	return langCommand,
+		runnerFileLocation,
+		nil
 }
 
 func insertImportsJava(formattedCode *strings.Builder, settings *FileSettings) {

--- a/internal/executable/runner_python.go
+++ b/internal/executable/runner_python.go
@@ -6,7 +6,7 @@ import (
 )
 
 //Python creates a runnerFile for python languages.
-func createRunnerFilePython(code string, settings *FileSettings) (string, string) {
+func createRunnerFilePython(code string, settings *FileSettings) (string, string, error) {
 	settings = fillRestOfFileSettings("python", settings)
 	langCommand := "python3"
 	var fileName strings.Builder
@@ -25,7 +25,7 @@ func createRunnerFilePython(code string, settings *FileSettings) (string, string
 	if err != nil {
 		log.Fatal("Could not create runner file!")
 	}
-	return langCommand, outFileName
+	return langCommand, outFileName, nil
 }
 
 func insertImportsPython(formattedCode *strings.Builder, settings *FileSettings) {

--- a/internal/executable/types.go
+++ b/internal/executable/types.go
@@ -2,7 +2,7 @@ package executable
 
 //Executable represents program that is ready to execute
 type Executable interface {
-	Run() string
+	Run() (string, error)
 }
 
 //FileSettings holds the settings for a runner file
@@ -23,7 +23,7 @@ type executableState struct {
 	createFile fileCreationFunction
 }
 
-type fileCreationFunction func(string, *FileSettings) (string, string)
+type fileCreationFunction func(string, *FileSettings) (string, string, error)
 
 var supportedLanguages = map[string]fileCreationFunction{
 	"python": createRunnerFilePython,

--- a/internal/executable/types_errors.go
+++ b/internal/executable/types_errors.go
@@ -11,3 +11,32 @@ type UnsupportedLanguageError struct {
 func (ule *UnsupportedLanguageError) Error() string {
 	return fmt.Sprintf("%s is not a supported language", ule.lang)
 }
+
+//CompilationError is the error returned by Run() if the provided source code
+//could not compile.
+type CompilationError struct {
+	errMessage string
+}
+
+func (ce *CompilationError) Error() string {
+	return fmt.Sprintf("Error, could not compile source code:\n %s", ce.errMessage)
+}
+
+//TimeLimitExceeded is returned if the max the exectuable took to long to run
+type TimeLimitExceeded struct {
+	maxTime int
+}
+
+func (tle *TimeLimitExceeded) Error() string {
+	return fmt.Sprintf("Time Limit Exceeded %ds", tle.maxTime)
+}
+
+//RuntimeError is returned if the executable had a runtime erorr during
+//execution.
+type RuntimeError struct {
+	errMessage string
+}
+
+func (re *RuntimeError) Error() string {
+	return re.errMessage
+}

--- a/internal/executable/types_errors.go
+++ b/internal/executable/types_errors.go
@@ -22,12 +22,12 @@ func (ce *CompilationError) Error() string {
 	return fmt.Sprintf("Error, could not compile source code:\n %s", ce.errMessage)
 }
 
-//TimeLimitExceeded is returned if the max the exectuable took to long to run
-type TimeLimitExceeded struct {
+//TimeLimitExceededError is returned if the max the exectuable took to long to run
+type TimeLimitExceededError struct {
 	maxTime int
 }
 
-func (tle *TimeLimitExceeded) Error() string {
+func (tle *TimeLimitExceededError) Error() string {
 	return fmt.Sprintf("Time Limit Exceeded %ds", tle.maxTime)
 }
 

--- a/internal/executable/types_errors.go
+++ b/internal/executable/types_errors.go
@@ -1,0 +1,13 @@
+package executable
+
+import "fmt"
+
+//UnsupportedLanguageError is the error returned by NewExecutable if
+//the language provided is not supported.
+type UnsupportedLanguageError struct {
+	lang string
+}
+
+func (ule *UnsupportedLanguageError) Error() string {
+	return fmt.Sprintf("%s is not a supported language", ule.lang)
+}


### PR DESCRIPTION
# Added types_errors.go
* Added 4 new error types
    * UnsupportedLanguageError
    * CompilationError
    * TimeLimitExceededError
    * Runtime Error
* These errors will be used through out the package to differentiate between different error types. 

# executable.go
* Slightly changed NewExecutable logic so we didn't have to create an extra variable just to return it.
* Changed NewExecutable so it returns and UnsupportedLanguageError instead of a generic error.
* Changed Run's return type to (string, error) so it can return the new errors
    * Small changes through out Run() so it can return RuntimeErrors and TimeLimitExceeededErrors
    * @joshua-sterner do you want to combine RuntimeErrors and TimeLimitExceededErrors? I could see them as being one thing. What is easier from the server's perspective? 

# Test Files
* Changed test files to check to make sure they are getting the proper error type.

# All runner_XXXX.go files
* Changed their fileCreationFunction's return time to also return an error so we can check for compilation errors. 
    * Currently none of the languages we support need to be compiled but this is just setting up for future languages. 

# runner_java.go
* Renamed some variables for easier readability. 

# types.go
* Changed signature of the Run() method in the Executable interface
* Changed return type for fileCreationFunctions from (string, string) -> (string, string, error)


@joshua-sterner I am going to let you approve this merge because these changes are going to be mostly implemented by the server package. Let me know if you have any questions. 